### PR TITLE
DryIoc.Microsoft.DependencyInjection 2.1.0 behaves different than Microsoft

### DIFF
--- a/test/DryIoc.Microsoft.DependencyInjection.Specification.Tests/DryIocAdapterSpecificationTests.cs
+++ b/test/DryIoc.Microsoft.DependencyInjection.Specification.Tests/DryIocAdapterSpecificationTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection.Specification;
+using NUnit.Framework;
 
 // uncomment when I want to copy some test here for testing.
 //using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
@@ -14,6 +16,51 @@ namespace DryIoc.Microsoft.DependencyInjection.Specification.Tests
         protected override IServiceProvider CreateServiceProvider(IServiceCollection services) => DryIocAdapter.Create(services);
 
         internal class TestServiceCollection : List<ServiceDescriptor>, IServiceCollection
+        {
+        }
+
+        public static object[] LifetimeCombinations =
+        {
+          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Transient, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Transient, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Transient, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Scoped, typeof(ServiceB) },
+        };
+
+        [Test, TestCaseSource(nameof(LifetimeCombinations))]
+        public void Resolve_single_service_with_multiple_registrations_should_resolve_the_same_way_as_microsoft_di(ServiceLifetime firstLifetime, ServiceLifetime secondLifetime, Type expectedResolveType)
+        {
+            // arrange
+            var collection = new ServiceCollection();
+            collection.Add(ServiceDescriptor.Describe(typeof(IService), typeof(ServiceA), firstLifetime));
+            collection.Add(ServiceDescriptor.Describe(typeof(IService), typeof(ServiceB), secondLifetime));
+
+            var msProvider = collection.BuildServiceProvider();
+            var dryiocProvider = new Container().WithDependencyInjectionAdapter(collection).BuildServiceProvider();
+
+            // act
+            var msService = msProvider.GetRequiredService<IService>();
+            var dryiocService = dryiocProvider.GetRequiredService<IService>();
+
+            // assert
+            Assert.IsInstanceOf(expectedResolveType, msService, "Microsoft changed the implementation");
+            Assert.IsInstanceOf(expectedResolveType, dryiocService, "DryIoc resolves the requested type different than microsofts di implementation");
+        }
+
+        public interface IService
+        {
+        }
+
+        public class ServiceA : IService
+        {
+        }
+
+        public class ServiceB : IService
         {
         }
     }

--- a/test/DryIoc.Microsoft.DependencyInjection.Specification.Tests/DryIocAdapterSpecificationTests.cs
+++ b/test/DryIoc.Microsoft.DependencyInjection.Specification.Tests/DryIocAdapterSpecificationTests.cs
@@ -21,27 +21,42 @@ namespace DryIoc.Microsoft.DependencyInjection.Specification.Tests
 
         public static object[] LifetimeCombinations =
         {
-          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Singleton, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Transient, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Singleton, ServiceLifetime.Scoped, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Transient, ServiceLifetime.Singleton, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Transient, ServiceLifetime.Transient, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Transient, ServiceLifetime.Scoped, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Singleton, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Transient, typeof(ServiceB) },
-          new object[] { ServiceLifetime.Scoped, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Singleton, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Singleton, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Singleton, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Transient, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Transient, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Transient, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Scoped, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Scoped, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { false, ServiceLifetime.Scoped, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Singleton, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Singleton, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Singleton, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Transient, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Transient, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Transient, ServiceLifetime.Scoped, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Scoped, ServiceLifetime.Singleton, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Scoped, ServiceLifetime.Transient, typeof(ServiceB) },
+          new object[] { true, ServiceLifetime.Scoped, ServiceLifetime.Scoped, typeof(ServiceB) },
         };
 
         [Test, TestCaseSource(nameof(LifetimeCombinations))]
-        public void Resolve_single_service_with_multiple_registrations_should_resolve_the_same_way_as_microsoft_di(ServiceLifetime firstLifetime, ServiceLifetime secondLifetime, Type expectedResolveType)
+        public void Resolve_single_service_with_multiple_registrations_should_resolve_the_same_way_as_microsoft_di(bool usingScope, ServiceLifetime firstLifetime, ServiceLifetime secondLifetime, Type expectedResolveType)
         {
             // arrange
             var collection = new ServiceCollection();
             collection.Add(ServiceDescriptor.Describe(typeof(IService), typeof(ServiceA), firstLifetime));
             collection.Add(ServiceDescriptor.Describe(typeof(IService), typeof(ServiceB), secondLifetime));
 
-            var msProvider = collection.BuildServiceProvider();
-            var dryiocProvider = new Container().WithDependencyInjectionAdapter(collection).BuildServiceProvider();
+            IServiceProvider msProvider = collection.BuildServiceProvider();
+            IServiceProvider dryiocProvider = new Container().WithDependencyInjectionAdapter(collection).BuildServiceProvider();
+
+            if (usingScope)
+            {
+              msProvider = msProvider.CreateScope().ServiceProvider;
+              dryiocProvider = dryiocProvider.CreateScope().ServiceProvider;
+            }
 
             // act
             var msService = msProvider.GetRequiredService<IService>();


### PR DESCRIPTION
Hi!
We're using DryIoc for a couple of months now and I noticed that, when used with IServiceCollection, it behaves strange.

To give you a picture how I recognized the problem:
We use identity for managing users in aspnet core2 with something like this
```cs
public class Startup {
  public IServiceProvider ConfigureServices(IServiceCollection services) {
    services
      // (1) adds default implementation of IUserClaimsPrincipalFactory as scoped
      .AddIdentity<ApplicationUser, IdentityRole>()
      // (2) adds the replacement for IUserClaimsPrincipalFactory as scoped
      .AddClaimsPrincipalFactory<CustomUserClaimsPrincipalFactory>();
    services
      .AddIdentityServer()
      // (3) removes the service (2) IUserClaimsPrincipalFactory and adds a transient implementation of IUserClaimsPrincipalFactory
      .AddAspNetIdentity();

    var container = new Container();
    // (4) create DryIoc-ServiceProvider
    var provider = container.WithDependencyInjectionAdapter(services).BuildServiceProvider();
    return provider;
  }
}
```
For some reason I always got the first service (1) resolved when asking the (4) DryIoC-ServiceProvider.
What I found out was that even though (1) and (2) weren't no problem, the combination of Scoped and then Transient wasn't resolved as it would be with microsofts IServiceProvider only.

So I made some tests to proof my theory (in the PR):
The test is checking all combinations of registration of two implementation as the same service with the lifetimes of Singleton, Transient and Scope.
Then it checks if the outcome of DryIoc is the same as the one from Microsoft.

| via CONTAINER | Singleton | Transient | Scoped |
|-----------|-----------|-----------|--------|
| Singleton | OK        | Fail      | Fail   |
| Transient | OK        | OK        | Fail   |
| Scoped    | OK        | OK        | OK     |

| via SCOPED | Singleton | Transient | Scoped |
|-----------|-----------|-----------|--------|
| Singleton | OK        | Fail      | OK   |
| Transient | OK        | OK        | OK   |
| Scoped    | Fail        | Fail        | OK     |

As you can see there 6 differences in total and I guess these problems should be fixed in order to be fully compatible with IServiceProvider.
I really tried to get the problems fixed, but reflection, lambda and compiled expressions aren't my domain so I was only able to track the issue to [this line](https://github.com/dadhi/DryIoc/blob/a8030e1d762fc2eb79aee42c4f2d1a86b34723bc/src/DryIoc/Container.cs#L6983).

I've seen that you introduced a new Rule called `Rules.MicrosoftDependencyInjectionRules`.
Maybe you can patch it there?

Thank you very much for this wonderful library!