### PR TITLE
Speculative Support for Source Files + New Sdk + net35/net45

### DIFF
--- a/nuspecs/DryIoc.nuspec
+++ b/nuspecs/DryIoc.nuspec
@@ -99,17 +99,29 @@
         <file src="..\src\DryIoc\Container.cs" target="content\net35\DryIoc" />
         <file src="..\src\DryIoc\ImTools.cs" target="content\net35\DryIoc" />
         <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="content\net35\DryIoc" />
+        <file src="..\src\DryIoc\Container.cs" target="contentFiles\cs\net35\DryIoc" />
+        <file src="..\src\DryIoc\ImTools.cs" target="contentFiles\cs\net35\DryIoc" />
+        <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="contentFiles\cs\net35\DryIoc" />
+        <file src="..\src\DryIoc\Expression.cs" target="contentFiles\cs\net35\DryIoc" />
 
         <!--net40-->
         <file src="..\src\DryIoc\Container.cs" target="content\net40\DryIoc" />
         <file src="..\src\DryIoc\ImTools.cs" target="content\net40\DryIoc" />
         <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="content\net40\DryIoc" />
+        <file src="..\src\DryIoc\Container.cs" target="contentFiles\cs\net40\DryIoc" />
+        <file src="..\src\DryIoc\ImTools.cs" target="contentFiles\cs\net40\DryIoc" />
+        <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="contentFiles\cs\net40\DryIoc" />
+        <file src="..\src\DryIoc\Expression.cs" target="contentFiles\cs\net40\DryIoc" />
 
         <!--net45-->
         <file src="..\src\DryIoc\Container.cs" target="content\net45\DryIoc" />
         <file src="..\src\DryIoc\ImTools.cs" target="content\net45\DryIoc" />
         <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="content\net45\DryIoc" />
         <file src="..\src\DryIoc\Expression.cs" target="content\net45\DryIoc" />
+        <file src="..\src\DryIoc\Container.cs" target="contentFiles\cs\net45\DryIoc" />
+        <file src="..\src\DryIoc\ImTools.cs" target="contentFiles\cs\net45\DryIoc" />
+        <file src="..\src\DryIoc\FastExpressionCompiler.cs" target="contentFiles\cs\net45\DryIoc" />
+        <file src="..\src\DryIoc\Expression.cs" target="contentFiles\cs\net45\DryIoc" />
 
         <!-- .netstandard 1.0 (based on PCL Profile259) -->
         <file src="..\src\DryIoc\Container.cs" target="contentFiles\cs\netstandard1.0\DryIoc" />


### PR DESCRIPTION
This pr attempts to add support for source files when using the new sdk to build net monikers e.g. net35.

🙏 🤞 

I've have seen no documentation if this is supported, nor have I found any issues disproving it. I'm going to conclude this is a very niche request i.e we have an application that needs to support net35 and netcoreapp.

Hopefully this pr triggers the CI server, so that I can test using completed packages.