### PR TITLE
Ignore static constructors in ReflectionTools constructor-getter methods

### DIFF
--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -11560,7 +11560,7 @@ namespace DryIoc
         public static ConstructorInfo GetConstructorOrNull(this Type type, bool includeNonPublic = false, params Type[] args)
         {
             var argsLength = args.Length;
-            var ctors = type.GetTypeInfo().DeclaredConstructors.ToArrayOrSelf();
+            var ctors = Constructors(type, includeNonPublic, includeStatic: false).ToArrayOrSelf();
             for (var c = 0; c < ctors.Length; c++)
             {
                 var ctor = ctors[c];
@@ -11598,7 +11598,7 @@ namespace DryIoc
         public static ConstructorInfo GetSingleConstructorOrNull(this Type type, bool includeNonPublic = false)
         {
             ConstructorInfo ctor = null;
-            var ctors = type.GetTypeInfo().DeclaredConstructors.ToArrayOrSelf();
+            var ctors = Constructors(type, includeNonPublic, includeStatic: false).ToArrayOrSelf();
             for (var i = 0; i < ctors.Length; i++)
             {
                 var x = ctors[i];

--- a/test/DryIoc.IssuesTests/GHIssue184_ReflectionTools_returns_static_constructors.cs
+++ b/test/DryIoc.IssuesTests/GHIssue184_ReflectionTools_returns_static_constructors.cs
@@ -1,0 +1,115 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace DryIoc.IssuesTests
+{
+    public class GHIssue184_ReflectionTools_returns_static_constructors
+    {
+        [Test]
+        [TestCaseSource(nameof(SingleConstructors))]
+        public void GetConstructorOrNull_DoesNotReturnStaticConstructor(Type type)
+        {
+            Assert.IsNull(
+                type.GetConstructorOrNull());
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DoubleConstructors))]
+        public void GetConstructorOrNull_ReturnsDoubleConstructorWithArguments(Type type)
+        {
+            Assert.IsInstanceOf<ConstructorInfo>(
+                type.GetConstructorOrNull(typeof(object)));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DoubleConstructors))]
+        public void GetConstructorOrNull_ReturnsDoubleConstructorWithoutArguments(Type type)
+        {
+            var ctor = type.GetConstructorOrNull();
+
+            Assert.IsInstanceOf<ConstructorInfo>(ctor);
+            Assert.IsFalse(ctor.IsStatic);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SingleConstructors))]
+        public void GetConstructorOrNull_ReturnsSingleConstructorWithArguments(Type type)
+        {
+            Assert.IsInstanceOf<ConstructorInfo>(
+                type.GetConstructorOrNull(typeof(object)));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SingleConstructors))]
+        public void GetSingleConstructorOrNull_ReturnsSingleConstructor(Type type)
+        {
+            Assert.IsInstanceOf<ConstructorInfo>(
+                type.GetSingleConstructorOrNull());
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DoubleConstructors))]
+        public void GetSingleConstructorOrNull_ReturnsNullForDoubleConstructor(Type type)
+        {
+            Assert.IsNull(
+                type.GetSingleConstructorOrNull());
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SingleConstructors))]
+        public void SingleConstructor_DoesNotThrowForStaticConstructor(Type type)
+        {
+            Assert.IsInstanceOf<ConstructorInfo>(
+                type.SingleConstructor());
+        }
+
+        [Test]
+        [TestCaseSource(nameof(DoubleConstructors))]
+        public void SingleConstructor_ThrowsForDoubleConstructor(Type type)
+        {
+            Assert.Throws<ContainerException>(
+                () => type.SingleConstructor());
+        }
+
+        private static readonly object[] SingleConstructors = new[]
+        {
+            typeof(SingleConstructorWithStaticConstructor1),
+            typeof(SingleConstructorWithStaticConstructor2),
+        };
+
+        private static readonly object[] DoubleConstructors = new[]
+        {
+            typeof(DoubleConstructorWithStaticConstructor1),
+            typeof(DoubleConstructorWithStaticConstructor2),
+        };
+
+        private class SingleConstructorWithStaticConstructor1
+        {
+            static SingleConstructorWithStaticConstructor1() { }
+            public SingleConstructorWithStaticConstructor1(object param) { }
+        }
+
+        private class SingleConstructorWithStaticConstructor2
+        {
+            public SingleConstructorWithStaticConstructor2(object param) { }
+            static SingleConstructorWithStaticConstructor2() { }
+        }
+
+        private class DoubleConstructorWithStaticConstructor1
+        {
+            static DoubleConstructorWithStaticConstructor1() { }
+            public DoubleConstructorWithStaticConstructor1() { }
+            public DoubleConstructorWithStaticConstructor1(object param) { }
+        }
+
+        private class DoubleConstructorWithStaticConstructor2
+        {
+            public DoubleConstructorWithStaticConstructor2() { }
+            public DoubleConstructorWithStaticConstructor2(object param) { }
+            static DoubleConstructorWithStaticConstructor2() { }
+        }
+    }
+}


### PR DESCRIPTION
Use `Constructors(type, includeNonPublic, includeStatic: false)` to get the list of constructors these methods consider to satisfy their criteria. Note in some of the test cases, the outcome depends on the order in which the constructors are declared!

fixes #184