### PR TITLE
Avoid instantiating the CompilerGeneratedAttribute

### DIFF
--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -14074,7 +14074,7 @@ namespace DryIoc
         /// <summary>Returns true if class is compiler generated. Checking for CompilerGeneratedAttribute
         /// is not enough, because this attribute is not applied for classes generated from "async/await".</summary>
         public static bool IsCompilerGenerated(this Type type) =>
-            type.GetTypeInfo().GetCustomAttributes(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute), false).Any();
+            type.GetTypeInfo().IsDefined(typeof(System.Runtime.CompilerServices.CompilerGeneratedAttribute), false);
 
         /// <summary>Returns true if type is generic.</summary>
         public static bool IsGeneric(this Type type) =>

--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -14921,6 +14921,7 @@ namespace System.Reflection
             _type.GetCustomAttributes(attributeType, inherit).Cast<Attribute>();
 
         public Type BaseType => _type.BaseType;
+        public bool IsDefined(Type attributeType, bool inherit) => _type.IsDefined(attributeType, inherit);
         public bool IsGenericType => _type.IsGenericType;
         public bool IsGenericTypeDefinition => _type.IsGenericTypeDefinition;
         public bool ContainsGenericParameters => _type.ContainsGenericParameters;

--- a/test/DryIoc.UnitTests/TypeToolsTests.cs
+++ b/test/DryIoc.UnitTests/TypeToolsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NUnit.Framework;
 
 namespace DryIoc.UnitTests
@@ -55,6 +55,18 @@ namespace DryIoc.UnitTests
             var types = typeof(B).GetImplementedTypes(ReflectionTools.AsImplementedType.ObjectType);
 
             Assert.That(types, Is.EqualTo(new[] { typeof(IB), typeof(C), typeof(object) }));
+        }
+
+        [Test]
+        public void IsCompilerGenerated_returns_false_for_string_type()
+        {
+            Assert.That(typeof(string).IsCompilerGenerated(), Is.False);
+        }
+
+        [Test]
+        public void IsCompilerGenerated_returns_true_for_anonymous_type()
+        {
+            Assert.That(new { }.GetType().IsCompilerGenerated(), Is.True);
         }
     }
 


### PR DESCRIPTION
Not sure if it's still relevant, but anyway here it is.

`IsCompilerGenerated` extension method doesn't need `CompilerGeneratedAttribute` instance.
So it can use cheaper `IsDefined` method to check whether the attribute is defined.
Quick and dirty benchmark shows that it's faster indeed.

1. For a type that's compiler-generated:
![image](https://user-images.githubusercontent.com/672878/153296877-ea7ec3b7-0bc5-4f48-8b6d-78b0848c6592.png)

2. For a type that's not compiler-generated:
![image](https://user-images.githubusercontent.com/672878/153297012-021cb94c-d307-4a0e-806e-0afa325e8827.png)
