### PR TITLE
Fix GetWrappedType implementation(s) to not return null

### DIFF
--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -1661,11 +1661,7 @@ namespace DryIoc
             {
                 var factory = ((IContainer)this).GetWrapperFactoryOrDefault(serviceType);
                 if (factory != null)
-                {
                     wrappedType = ((Setup.WrapperSetup)factory.Setup).GetWrappedTypeOrNullIfWrapsRequired(serviceType);
-                    if (wrappedType == null)
-                        return null;
-                }
             }
 
             return wrappedType == null ? serviceType : ((IContainer)this).GetWrappedType(wrappedType);

--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -1556,11 +1556,7 @@ namespace DryIoc
             {
                 var factory = ((IContainer)this).GetWrapperFactoryOrDefault(serviceType);
                 if (factory != null)
-                {
                     wrappedType = ((Setup.WrapperSetup)factory.Setup).GetWrappedTypeOrNullIfWrapsRequired(serviceType);
-                    if (wrappedType == null)
-                        return null;
-                }
             }
 
             return wrappedType == null ? serviceType : ((IContainer)this).GetWrappedType(wrappedType);


### PR DESCRIPTION
Motivation for this change:
I tried to resolve `IContainer` through third-party `Splat.DryIoc` dependency resolver in my app (bad practice but WinForms is a bad practice by itself, so eh). It errored with a `NullReferenceException` here (none of the params were generic):
https://github.com/dadhi/DryIoc/blob/e6a4e33e55470fa0d187b4d651bd5bbef4aabc56/src/DryIoc/Container.cs#L5072-L5077

Upon further inspection I found out that the methods shouldn't ever return `null`, according to documentation:
https://github.com/dadhi/DryIoc/blob/e6a4e33e55470fa0d187b4d651bd5bbef4aabc56/src/DryIoc/Container.cs#L14054
And here:
https://github.com/dadhi/DryIoc/blob/e6a4e33e55470fa0d187b4d651bd5bbef4aabc56/src/DryIoc/Container.cs#L14059

Yet one of the branches was seemingly erratically returning null, so I fixed that.