### PR TITLE
Include DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests project

### DIFF
--- a/DryIoc.sln
+++ b/DryIoc.sln
@@ -116,17 +116,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DryIoc", "DryIoc", "{1858EE
 		nuspecs\DryIoc\readme.md = nuspecs\DryIoc\readme.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DryIoc.TestRunner", "test\DryIoc.TestRunner\DryIoc.TestRunner.csproj", "{755CC987-E7B6-46CD-B612-D33B28EBD1A8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DryIoc.TestRunner", "test\DryIoc.TestRunner\DryIoc.TestRunner.csproj", "{755CC987-E7B6-46CD-B612-D33B28EBD1A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DryIoc.AzureFunctions", "src\DryIoc.AzureFunctions\DryIoc.AzureFunctions.csproj", "{400BE898-DF9C-4DE8-9483-1F43F990784B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DryIoc.AzureFunctions", "src\DryIoc.AzureFunctions\DryIoc.AzureFunctions.csproj", "{400BE898-DF9C-4DE8-9483-1F43F990784B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DryIoc.Microsoft.DependencyInjection.Specification.Tests", "test\DryIoc.Microsoft.DependencyInjection.Specification.Tests\DryIoc.Microsoft.DependencyInjection.Specification.Tests.csproj", "{480C65D7-184D-44E7-9B5D-05E30D857977}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DryIoc.Microsoft.DependencyInjection.Specification.Tests", "test\DryIoc.Microsoft.DependencyInjection.Specification.Tests\DryIoc.Microsoft.DependencyInjection.Specification.Tests.csproj", "{480C65D7-184D-44E7-9B5D-05E30D857977}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground", "playground\Playground\Playground.csproj", "{AE6FA868-31E9-4726-9A8E-8BAB2ADD1F9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Playground", "playground\Playground\Playground.csproj", "{AE6FA868-31E9-4726-9A8E-8BAB2ADD1F9D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{38A94225-72AE-4869-88A2-61FCB48ED681}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test", "samples\GHIssue519\test.csproj", "{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "test", "samples\GHIssue519\test.csproj", "{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests", "test\DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests\DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests.csproj", "{91671AB0-0788-4912-94B9-386F3EA820B2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -266,6 +268,10 @@ Global
 		{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91671AB0-0788-4912-94B9-386F3EA820B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91671AB0-0788-4912-94B9-386F3EA820B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91671AB0-0788-4912-94B9-386F3EA820B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91671AB0-0788-4912-94B9-386F3EA820B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -304,6 +310,7 @@ Global
 		{480C65D7-184D-44E7-9B5D-05E30D857977} = {69DDE71E-F688-44E9-9A60-AB0DE2D270FF}
 		{AE6FA868-31E9-4726-9A8E-8BAB2ADD1F9D} = {85CE6F42-1A5A-4475-9E8C-D3090BCC6EED}
 		{0CAC5A1E-FEB3-4C12-929C-AB9EF9171F73} = {38A94225-72AE-4869-88A2-61FCB48ED681}
+		{91671AB0-0788-4912-94B9-386F3EA820B2} = {69DDE71E-F688-44E9-9A60-AB0DE2D270FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {722EDB85-282C-48BF-9384-BC9C5C230923}

--- a/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/CompileTimeGeneratedRegistrator.cs
+++ b/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/CompileTimeGeneratedRegistrator.cs
@@ -1,4 +1,4 @@
-﻿namespace DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests
+namespace DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests
 {
     using System;
 
@@ -159,7 +159,7 @@
     new ExportedRegistrationInfo {
         ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.OneTransientService),
         Exports = new[] {
-            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplentations), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
+            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplementations), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
         },
         Reuse = new ReuseInfo { ReuseType = DryIocAttributes.ReuseType.Transient },
         OpenResolutionScope = false,
@@ -175,7 +175,7 @@
         ConditionType = null,
         Metadata = new System.Collections.Generic.Dictionary<string, Object> {
             { "DisplayName", "One" },
-            { "DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute", new DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplentations), "One") },
+            { "DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute", new DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplementations), "One") },
             { "DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute.ToCode()", "new DryIoc.MefAttributedModel.UnitTests.CUT.ExportWithDisplayNameAttribute(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplentations), \"One\")" },
         }
     },
@@ -183,7 +183,7 @@
     new ExportedRegistrationInfo {
         ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.AnotherTransientService),
         Exports = new[] {
-            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplentations), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
+            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.IServiceWithMultipleImplementations), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
         },
         Reuse = new ReuseInfo { ReuseType = DryIocAttributes.ReuseType.Transient },
         OpenResolutionScope = false,
@@ -271,9 +271,9 @@
     },
 
     new ExportedRegistrationInfo {
-        ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleCostructors),
+        ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleConstructors),
         Exports = new[] {
-            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleCostructors), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
+            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleConstructors), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
         },
         OpenResolutionScope = false,
         AsResolutionCall = false,
@@ -289,9 +289,9 @@
     },
 
     new ExportedRegistrationInfo {
-        ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleCostructorsAndOneImporting),
+        ImplementationType = typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleConstructorsAndOneImporting),
         Exports = new[] {
-            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleCostructorsAndOneImporting), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
+            new ExportInfo(typeof(DryIoc.MefAttributedModel.UnitTests.CUT.ServiceWithMultipleConstructorsAndOneImporting), null, DryIoc.IfAlreadyRegistered.AppendNotKeyed),
         },
         OpenResolutionScope = false,
         AsResolutionCall = false,

--- a/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests.csproj
+++ b/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProductVersion>8.0.30703</ProductVersion>
     <TargetFramework>net45</TargetFramework>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AssemblyTitle>DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests</AssemblyTitle>
     <Product>DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests</Product>
-    <Copyright>Copyright � 2013-2021 Maksim Volkau</Copyright>
+    <Copyright>Copyright � 2013-2023 Maksim Volkau</Copyright>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -22,7 +22,6 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="2.6.4" />
     <PackageReference Include="Wire" Version="0.8.0" />
   </ItemGroup>
   <ItemGroup>
@@ -42,12 +41,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DryIoc.MefAttributedModel.UnitTests.CUT\DryIoc.MefAttributedModel.UnitTests.CUT.csproj" />
-    <ProjectReference Include="..\DryIoc.MefAttributedModel\DryIoc.MefAttributedModel.csproj" />
-    <ProjectReference Include="..\DryIocAttributes\DryIocAttributes.csproj" />
-    <ProjectReference Include="..\DryIoc\DryIoc.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="CompileTimeGeneratedRegistrator.cs" />
+    <ProjectReference Include="..\..\src\DryIoc.MefAttributedModel\DryIoc.MefAttributedModel.csproj" />
+    <ProjectReference Include="..\..\src\DryIocAttributes\DryIocAttributes.csproj" />
+    <ProjectReference Include="..\..\src\DryIoc\DryIoc.csproj" />
+    <ProjectReference Include="..\..\test_sut\DryIoc.MefAttributedModel.UnitTests.CUT\DryIoc.MefAttributedModel.UnitTests.CUT.csproj" />
+    <ProjectReference Include="..\DryIoc.MefAttributedModel.UnitTests\DryIoc.MefAttributedModel.UnitTests.csproj" />
   </ItemGroup>
 </Project>

--- a/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/Properties/AssemblyInfo.cs
+++ b/test/DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/test_sut/DryIoc.MefAttributedModel.UnitTests.CUT/Properties/AssemblyInfo.cs
+++ b/test_sut/DryIoc.MefAttributedModel.UnitTests.CUT/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests")]
+


### PR DESCRIPTION
Hi Maksim,

looks like **DryIoc.MefAttributedModel.CompileTimeAssemblyScan.Tests** project was excluded from unit tests for some reason since ~2021. I've included it back, fixed a few typos in the class names. It's still works fine :)