### PR TITLE
FactoryMethod.ConstructorWithResolvableArguments is incompatible with dynamic registrations

### DIFF
--- a/src/DryIoc/Container.Generated.cs
+++ b/src/DryIoc/Container.Generated.cs
@@ -44,7 +44,7 @@ namespace DryIoc
     {
         partial void GetLastGeneratedFactoryID(ref int lastFactoryID)
         {
-            lastFactoryID = 716; // generated: equals to the last used Factory.FactoryID
+            lastFactoryID = 723; // generated: equals to the last used Factory.FactoryID
         }
 
         partial void ResolveGenerated(ref object service, Type serviceType)
@@ -62,7 +62,7 @@ namespace DryIoc
                     requiredServiceType == null &&
                     Equals(preRequestParent, Request.Empty.Push(
                         typeof(IService),
-                        711,
+                        718,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall)))
@@ -92,7 +92,7 @@ namespace DryIoc
                     null,
                     Request.Empty.Push(
                         typeof(IService),
-                        711,
+                        718,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall|RequestFlags.StopRecursiveDependencyCheck),
@@ -104,7 +104,7 @@ namespace DryIoc
                     null,
                     Request.Empty.Push(
                         typeof(IService),
-                        711,
+                        718,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall|RequestFlags.StopRecursiveDependencyCheck),

--- a/src/DryIoc/Container.Generated.cs
+++ b/src/DryIoc/Container.Generated.cs
@@ -44,7 +44,7 @@ namespace DryIoc
     {
         partial void GetLastGeneratedFactoryID(ref int lastFactoryID)
         {
-            lastFactoryID = 723; // generated: equals to the last used Factory.FactoryID
+            lastFactoryID = 716; // generated: equals to the last used Factory.FactoryID
         }
 
         partial void ResolveGenerated(ref object service, Type serviceType)
@@ -62,7 +62,7 @@ namespace DryIoc
                     requiredServiceType == null &&
                     Equals(preRequestParent, Request.Empty.Push(
                         typeof(IService),
-                        718,
+                        711,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall)))
@@ -92,7 +92,7 @@ namespace DryIoc
                     null,
                     Request.Empty.Push(
                         typeof(IService),
-                        718,
+                        711,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall|RequestFlags.StopRecursiveDependencyCheck),
@@ -104,7 +104,7 @@ namespace DryIoc
                     null,
                     Request.Empty.Push(
                         typeof(IService),
-                        718,
+                        711,
                         typeof(MyService),
                         Reuse.Transient,
                         RequestFlags.IsResolutionCall|RequestFlags.StopRecursiveDependencyCheck),

--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -6750,8 +6750,7 @@ namespace DryIoc
         private static FactoryMethod MostResolvableConstructor(Request request,
             BindingFlags additionalToPublicAndInstance = 0, Func<Type, ParameterInfo[], bool> condition = null)
         {
-            var reflectionFactory = ((ReflectionFactory)request.Factory);
-            var ctorsOrCtorOrType = reflectionFactory._implementationTypeOrProviderOrPubCtorOrCtors;
+            var ctorsOrCtorOrType = ((ReflectionFactory)request.Factory)._implementationTypeOrProviderOrPubCtorOrCtors;
             ConstructorInfo[] ctors = null;
             if (ctorsOrCtorOrType is ConstructorInfo ci)
             {
@@ -6763,7 +6762,7 @@ namespace DryIoc
                 ctors = cs;
             else if (ctorsOrCtorOrType is Type t)
                 ctors = t.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
-            else if (reflectionFactory.ImplementationType is Type it)
+            else if (ctorsOrCtorOrType is Func<Type> typeProvider && typeProvider() is Type it)
                 ctors = it.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
             else
                 Throw.It(Error.ImplTypeIsNotSpecifiedForAutoCtorSelection, request);
@@ -6953,8 +6952,7 @@ namespace DryIoc
 
         private static FactoryMethod Constructor(Request request, BindingFlags additionalToPublicAndInstance = 0)
         {
-            var reflectionFactory = ((ReflectionFactory)request.Factory);
-            var ctorsOrCtorOrType = reflectionFactory._implementationTypeOrProviderOrPubCtorOrCtors;
+            var ctorsOrCtorOrType = ((ReflectionFactory)request.Factory)._implementationTypeOrProviderOrPubCtorOrCtors;
             ConstructorInfo[] ctors = null;
             if (ctorsOrCtorOrType is ConstructorInfo ci)
             {
@@ -6966,7 +6964,7 @@ namespace DryIoc
                 ctors = cs;
             else if (ctorsOrCtorOrType is Type t)
                 ctors = t.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
-            else if (reflectionFactory.ImplementationType is Type it)
+            else if (ctorsOrCtorOrType is Func<Type> typeProvider && typeProvider() is Type it)
                 ctors = it.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
             else
                 Throw.It(Error.ImplTypeIsNotSpecifiedForAutoCtorSelection, request);

--- a/src/DryIoc/Container.cs
+++ b/src/DryIoc/Container.cs
@@ -6750,7 +6750,8 @@ namespace DryIoc
         private static FactoryMethod MostResolvableConstructor(Request request,
             BindingFlags additionalToPublicAndInstance = 0, Func<Type, ParameterInfo[], bool> condition = null)
         {
-            var ctorsOrCtorOrType = ((ReflectionFactory)request.Factory)._implementationTypeOrProviderOrPubCtorOrCtors;
+            var reflectionFactory = ((ReflectionFactory)request.Factory);
+            var ctorsOrCtorOrType = reflectionFactory._implementationTypeOrProviderOrPubCtorOrCtors;
             ConstructorInfo[] ctors = null;
             if (ctorsOrCtorOrType is ConstructorInfo ci)
             {
@@ -6762,6 +6763,8 @@ namespace DryIoc
                 ctors = cs;
             else if (ctorsOrCtorOrType is Type t)
                 ctors = t.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
+            else if (reflectionFactory.ImplementationType is Type it)
+                ctors = it.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
             else
                 Throw.It(Error.ImplTypeIsNotSpecifiedForAutoCtorSelection, request);
 
@@ -6950,7 +6953,8 @@ namespace DryIoc
 
         private static FactoryMethod Constructor(Request request, BindingFlags additionalToPublicAndInstance = 0)
         {
-            var ctorsOrCtorOrType = ((ReflectionFactory)request.Factory)._implementationTypeOrProviderOrPubCtorOrCtors;
+            var reflectionFactory = ((ReflectionFactory)request.Factory);
+            var ctorsOrCtorOrType = reflectionFactory._implementationTypeOrProviderOrPubCtorOrCtors;
             ConstructorInfo[] ctors = null;
             if (ctorsOrCtorOrType is ConstructorInfo ci)
             {
@@ -6962,6 +6966,8 @@ namespace DryIoc
                 ctors = cs;
             else if (ctorsOrCtorOrType is Type t)
                 ctors = t.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
+            else if (reflectionFactory.ImplementationType is Type it)
+                ctors = it.GetConstructors(BindingFlags.Public | BindingFlags.Instance | additionalToPublicAndInstance);
             else
                 Throw.It(Error.ImplTypeIsNotSpecifiedForAutoCtorSelection, request);
             return ctors.Length == 1 ? new FactoryMethod(ctors[0]) : null;

--- a/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
+++ b/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -32,12 +32,15 @@ namespace DryIoc.IssuesTests
             Assert.NotNull(commands);
             Assert.AreEqual(2, commands.Length);
 
-            // these tests fail:
+            // these tests work fine:
             Assert.NotNull(commands[0]);
             Assert.NotNull(commands[1]);
             Assert.NotNull(commands[0].Metadata);
             Assert.NotNull(commands[1].Metadata);
             Assert.AreEqual(3, commands[0].Metadata.ScriptID + commands[1].Metadata.ScriptID); // should be 1 and 2, in any order
+
+            // and instantiation also works fine:
+            Assert.IsNotNull(commands[0].Value);
         }
 
         // index: ServiceTypeFullName -> list of ServiceRegistrations
@@ -112,12 +115,12 @@ namespace DryIoc.IssuesTests
         }
 
         [Export(typeof(ICommand)), Script(1)]
-        public class Command1
+        public class Command1 : ICommand
         {
         }
 
         [Export(typeof(ICommand)), Script(2)]
-        public class Command2
+        public class Command2 : ICommand
         {
         }
     }

--- a/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
+++ b/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
@@ -25,21 +25,22 @@ namespace DryIoc.IssuesTests
 
             // attach the dynamic registration provider and try resolving the services
             var container = new Container().WithMef()
-                .With(r => r.WithDynamicRegistrations(GetDynamicRegistrations));
+                .With(r => r.WithDynamicRegistrations(GetDynamicRegistrations)
+                .With(FactoryMethod.ConstructorWithResolvableArguments));
 
             // resolve the commands lazily
             var commands = container.Resolve<Lazy<ICommand, IScriptMetadata>[]>();
             Assert.NotNull(commands);
             Assert.AreEqual(2, commands.Length);
 
-            // these tests work fine:
+            // lazy resolution part works fine:
             Assert.NotNull(commands[0]);
             Assert.NotNull(commands[1]);
             Assert.NotNull(commands[0].Metadata);
             Assert.NotNull(commands[1].Metadata);
             Assert.AreEqual(3, commands[0].Metadata.ScriptID + commands[1].Metadata.ScriptID); // should be 1 and 2, in any order
 
-            // and instantiation also works fine:
+            // instantiation fails with Error.ImplTypeIsNotSpecifiedForAutoCtorSelection
             Assert.IsNotNull(commands[0].Value);
         }
 

--- a/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
+++ b/test/DryIoc.IssuesTests/Issue486_CustomDynamicRegistrationProvider.cs
@@ -40,7 +40,7 @@ namespace DryIoc.IssuesTests
             Assert.NotNull(commands[1].Metadata);
             Assert.AreEqual(3, commands[0].Metadata.ScriptID + commands[1].Metadata.ScriptID); // should be 1 and 2, in any order
 
-            // instantiation fails with Error.ImplTypeIsNotSpecifiedForAutoCtorSelection
+            // instantiation should also work now:
             Assert.IsNotNull(commands[0].Value);
         }
 


### PR DESCRIPTION
Looks like `WithDynamicRegistrations` rule conflicts with `FactoryMethod.ConstructorWithResolvableArguments`.
I'm going to prove it and then try to fix in a next few commits.
The first commit should pass all current tests, and the second one should fail.