### PR TITLE
Added missing IMessageMiddleware interface

### DIFF
--- a/src/DryIoc/Messages.cs
+++ b/src/DryIoc/Messages.cs
@@ -43,6 +43,9 @@ namespace DryIoc.Messages
     /// <summary>Base message handler for message with empty response</summary>
     public interface IMessageHandler<in M> : IMessageHandler<M, EmptyResponse> where M : IMessage<EmptyResponse> { }
 
+    /// <summary>Message handler middleware for message with empty response</summary>
+    public interface IMessageMiddleware<in M> : IMessageMiddleware<M, EmptyResponse> { }
+
     /// <summary>Message handler middleware to handle the message and pass the result to the next middleware</summary>
     public interface IMessageMiddleware<in M, R>
     {


### PR DESCRIPTION
This is a very small improvement.

I was working on my private project and was porting my project from ```MediatR``` to ```DryIoc.Messages```. 
I was just wondering why the ```IMessageMiddleware<in M>``` interface is missing? 
Is there a reason for it? Or am I missing something here?

I would love to have it in, because I would use it, but of course I could just declare it in my project.
But I thought for completeness sake, it would make sense to add it here.
