### PR TITLE
Added a failing test for ConstructorWithResolvableArguments, #710

### DIFF
--- a/test/DryIoc.IssuesTests/GHIssue710_ConstructorWithResolvableArguments_conflicts_with_Mef.cs
+++ b/test/DryIoc.IssuesTests/GHIssue710_ConstructorWithResolvableArguments_conflicts_with_Mef.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel.Composition;
+using DryIoc;
+using DryIoc.MefAttributedModel;
+using NUnit.Framework;
+
+namespace DryIoc.IssuesTests;
+
+[TestFixture]
+public class GHIssue710_ConstructorWithResolvableArguments_conflicts_with_Mef : ITest
+{
+    public int Run()
+    {
+        Original_case();
+        return 1;
+    }
+
+    public interface IServer
+    {
+        void Hello();
+    }
+
+    public interface IPrinter
+    {
+        void Print(string s);
+    }
+
+    [Export(typeof(IServer))]
+    public class Server : IServer
+    {
+        [Import]
+        internal IPrinter Printer { get; set; }
+
+        public void Hello() => Printer.Print("Hello!");
+    }
+
+    [Export(typeof(IPrinter))]
+    public class Printer : IPrinter
+    {
+        public void Print(string s) => Console.WriteLine(s);
+    }
+
+    [Test]
+    public void Original_case()
+    {
+        var c = new Container().WithMef()
+            .With(rules => rules
+            .With(FactoryMethod.ConstructorWithResolvableArguments)
+        );
+
+        c.RegisterExports(typeof(Server), typeof(Printer));
+
+        var root = c.Resolve<IServer>();
+        Assert.That(root, Is.Not.Null, "Root is not resolved");
+
+        var server = root as Server;
+        Assert.That(server.Printer, Is.Not.Null, "Import is not satisfied");
+
+        root.Hello();
+    }
+}

--- a/test/DryIoc.TestRunner/Program.cs
+++ b/test/DryIoc.TestRunner/Program.cs
@@ -34,8 +34,8 @@ public class Program
         Console.WriteLine("USE_COMPILATION_ONLY=true");
         Rules.UnsafeResetDefaultRulesToUseCompilationOnly();
 #endif
-        // note: @important to remember to do the Thread.Sleep in tests less that this setting, 
-        // if you don't intentionally want the Error.WaitForScopedServiceIsCreatedTimeoutExpired exception, 
+        // note: @important to remember to do the Thread.Sleep in tests less that this setting,
+        // if you don't intentionally want the Error.WaitForScopedServiceIsCreatedTimeoutExpired exception,
         // e.g. see GHIssue337_Singleton_is_created_twice, GHIssue391_Deadlock_during_Resolve, Issue157_ContainerResolveFactoryIsNotThreadSafe
 #if DEBUG
         Scope.WaitForScopedServiceIsCreatedTimeoutMilliseconds = 2_000;
@@ -439,6 +439,7 @@ public class Program
             new GHIssue669_Unable_to_resolve_type_with_optional_arguments_with_both_MefAttributedModel_and_MS_DI(),
             new GHIssue678_Scope_is_lost_in_disposable_service(),
             new GHIssue685_Creating_scopes_via_funcs_is_not_threadsafe_and_fails_sporadically_with_NullRef_exception(),
+            new GHIssue710_ConstructorWithResolvableArguments_conflicts_with_Mef(),
         };
 
         var totalPassed = 0;


### PR DESCRIPTION
Fails:

```c#
var c = new Container().WithMef()
    .With(rules => rules
    .With(FactoryMethod.ConstructorWithResolvableArguments)
);
```
Works:
```c#
var c = new Container().WithMef()
    .With(rules => rules
    //.With(FactoryMethod.ConstructorWithResolvableArguments)
);
```